### PR TITLE
[Feat] 러닝 중 Android foreground notification에 거리/시간/페이스 표시

### DIFF
--- a/hooks/useLocationTracking.ts
+++ b/hooks/useLocationTracking.ts
@@ -26,9 +26,24 @@ import {
 } from "@/lib/discriminateRecordType";
 import { useCourseStore } from "@/store/useCourseStore";
 import {
+  BG_NOTIFICATION_METRICS_KEY,
+  BG_NOTIFICATION_UPDATED_AT_KEY,
   buildBackgroundLocationOptions,
   RUNNING_NOTIFICATION_UPDATE_INTERVAL_MS,
 } from "@/lib/runningNotification";
+
+const setNotificationMetrics = async ({
+  distance,
+  seconds,
+}: {
+  distance: number;
+  seconds: number;
+}) => {
+  await AsyncStorage.setItem(
+    BG_NOTIFICATION_METRICS_KEY,
+    JSON.stringify({ distance, seconds })
+  );
+};
 
 export const useLocationTracking = () => {
   const subscription = useRef<Location.LocationSubscription | null>(null);
@@ -111,13 +126,17 @@ export const useLocationTracking = () => {
     if (!hasBackgroundPermission) return;
 
     await AsyncStorage.setItem(BG_RUNNING_FLAG_KEY, "true");
+    const runningState = useRunningStore.getState();
+    await setNotificationMetrics({
+      distance: runningState.runDistance,
+      seconds: runningState.seconds,
+    });
 
     const hasStarted = await Location.hasStartedLocationUpdatesAsync(
       BACKGROUND_LOCATION_TASK
     ).catch(() => false);
 
     if (!hasStarted) {
-      const runningState = useRunningStore.getState();
       await Location.startLocationUpdatesAsync(
         BACKGROUND_LOCATION_TASK,
         buildBackgroundLocationOptions({
@@ -140,7 +159,12 @@ export const useLocationTracking = () => {
       );
     }
 
-    const keys = [BG_RUNNING_FLAG_KEY, BG_SECONDS_OFFSET_KEY];
+    const keys = [
+      BG_RUNNING_FLAG_KEY,
+      BG_SECONDS_OFFSET_KEY,
+      BG_NOTIFICATION_METRICS_KEY,
+      BG_NOTIFICATION_UPDATED_AT_KEY,
+    ];
     if (clearLocations) keys.push(BG_LOCATION_KEY);
     await AsyncStorage.multiRemove(keys);
   }, []);
@@ -257,6 +281,9 @@ export const useLocationTracking = () => {
       .then((hasStarted) => {
         if (!hasStarted || AppState.currentState !== "active") return;
         lastNotificationUpdateAt.current = now;
+        setNotificationMetrics({ distance: runDistance, seconds }).catch(
+          () => undefined
+        );
         return Location.startLocationUpdatesAsync(
           BACKGROUND_LOCATION_TASK,
           buildBackgroundLocationOptions({ distance: runDistance, seconds })
@@ -273,9 +300,17 @@ export const useLocationTracking = () => {
       if (nextAppState !== "active" && isRunning) {
         if (!wasActive) return;
 
+        const runningState = useRunningStore.getState();
         await AsyncStorage.multiSet([
           [BG_SECONDS_OFFSET_KEY, Date.now().toString()],
           [BG_RUNNING_FLAG_KEY, "true"],
+          [
+            BG_NOTIFICATION_METRICS_KEY,
+            JSON.stringify({
+              distance: runningState.runDistance,
+              seconds: runningState.seconds,
+            }),
+          ],
         ]);
 
         const currentLocation = useLocationStore.getState().myLocation;

--- a/hooks/useLocationTracking.ts
+++ b/hooks/useLocationTracking.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useRef } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Location from "expo-location";
-import { AppState, AppStateStatus, DeviceEventEmitter } from "react-native";
+import {
+  AppState,
+  AppStateStatus,
+  DeviceEventEmitter,
+  Platform,
+} from "react-native";
 import { useLocationStore } from "@/store/useLocationStore";
 import { useRunningStore } from "@/store/useRunningStore";
 import { useAlertStore } from "@/store/useAlertStore";
@@ -20,14 +25,21 @@ import {
   isSoloRunningRecord,
 } from "@/lib/discriminateRecordType";
 import { useCourseStore } from "@/store/useCourseStore";
+import {
+  buildBackgroundLocationOptions,
+  RUNNING_NOTIFICATION_UPDATE_INTERVAL_MS,
+} from "@/lib/runningNotification";
 
 export const useLocationTracking = () => {
   const subscription = useRef<Location.LocationSubscription | null>(null);
   const appState = useRef(AppState.currentState);
   const syncingRef = useRef(false);
+  const lastNotificationUpdateAt = useRef(0);
   const showError = useAlertStore((s) => s.showError);
   const setMyLocation = useLocationStore((s) => s.setMyLocation);
   const runningStatus = useRunningStore((state) => state.runningStatus);
+  const runDistance = useRunningStore((state) => state.runDistance);
+  const seconds = useRunningStore((state) => state.seconds);
   const isRunning = runningStatus === "go" || runningStatus === "countdown";
 
   const stopForegroundTracking = useCallback(() => {
@@ -105,19 +117,15 @@ export const useLocationTracking = () => {
     ).catch(() => false);
 
     if (!hasStarted) {
-      await Location.startLocationUpdatesAsync(BACKGROUND_LOCATION_TASK, {
-        accuracy: Location.Accuracy.BestForNavigation,
-        timeInterval: 2000,
-        distanceInterval: 1,
-        pausesUpdatesAutomatically: false,
-        showsBackgroundLocationIndicator: true,
-        foregroundService: {
-          notificationTitle: "러닝 중",
-          notificationBody: "백그라운드에서 위치를 추적하고 있습니다.",
-          notificationColor: "#4169E1",
-          killServiceOnDestroy: false,
-        },
-      });
+      const runningState = useRunningStore.getState();
+      await Location.startLocationUpdatesAsync(
+        BACKGROUND_LOCATION_TASK,
+        buildBackgroundLocationOptions({
+          distance: runningState.runDistance,
+          seconds: runningState.seconds,
+        })
+      );
+      lastNotificationUpdateAt.current = Date.now();
     }
   }, [ensureBackgroundPermission, ensureForegroundPermission]);
 
@@ -233,6 +241,29 @@ export const useLocationTracking = () => {
     stopBackgroundTracking,
     stopForegroundTracking,
   ]);
+
+  useEffect(() => {
+    if (Platform.OS !== "android" || !isRunning) return;
+
+    const now = Date.now();
+    if (
+      now - lastNotificationUpdateAt.current <
+      RUNNING_NOTIFICATION_UPDATE_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    Location.hasStartedLocationUpdatesAsync(BACKGROUND_LOCATION_TASK)
+      .then((hasStarted) => {
+        if (!hasStarted || AppState.currentState !== "active") return;
+        lastNotificationUpdateAt.current = now;
+        return Location.startLocationUpdatesAsync(
+          BACKGROUND_LOCATION_TASK,
+          buildBackgroundLocationOptions({ distance: runDistance, seconds })
+        );
+      })
+      .catch(() => undefined);
+  }, [isRunning, runDistance, seconds]);
 
   useEffect(() => {
     const handleAppStateChange = async (nextAppState: AppStateStatus) => {

--- a/lib/runningNotification.ts
+++ b/lib/runningNotification.ts
@@ -3,10 +3,33 @@ import { calculatePaceFromDistance } from "@/lib/convertSpeedToPace";
 import { formatTime } from "@/lib/formatTime";
 
 export const RUNNING_NOTIFICATION_UPDATE_INTERVAL_MS = 15000;
+export const BG_NOTIFICATION_METRICS_KEY = "@bg_notification_metrics";
+export const BG_NOTIFICATION_UPDATED_AT_KEY = "@bg_notification_updated_at";
 
-type RunningNotificationMetrics = {
+export type RunningNotificationMetrics = {
   distance: number;
   seconds: number;
+};
+
+export const parseRunningNotificationMetrics = (raw: string | null) => {
+  if (!raw) return { distance: 0, seconds: 0 };
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed?.distance === "number" &&
+      typeof parsed?.seconds === "number"
+    ) {
+      return {
+        distance: Math.max(0, parsed.distance),
+        seconds: Math.max(0, parsed.seconds),
+      };
+    }
+  } catch {
+    return { distance: 0, seconds: 0 };
+  }
+
+  return { distance: 0, seconds: 0 };
 };
 
 export const formatRunningDistance = (distance: number) => {

--- a/lib/runningNotification.ts
+++ b/lib/runningNotification.ts
@@ -1,0 +1,39 @@
+import * as Location from "expo-location";
+import { calculatePaceFromDistance } from "@/lib/convertSpeedToPace";
+import { formatTime } from "@/lib/formatTime";
+
+export const RUNNING_NOTIFICATION_UPDATE_INTERVAL_MS = 15000;
+
+type RunningNotificationMetrics = {
+  distance: number;
+  seconds: number;
+};
+
+export const formatRunningDistance = (distance: number) => {
+  return `${(Math.max(0, distance) / 1000).toFixed(2)}km`;
+};
+
+export const buildRunningNotificationBody = ({
+  distance,
+  seconds,
+}: RunningNotificationMetrics) => {
+  const pace = calculatePaceFromDistance(distance, seconds);
+  return `거리 ${formatRunningDistance(distance)} · 시간 ${formatTime(seconds)} · 페이스 ${pace}`;
+};
+
+export const buildBackgroundLocationOptions = ({
+  distance,
+  seconds,
+}: RunningNotificationMetrics): Location.LocationTaskOptions => ({
+  accuracy: Location.Accuracy.BestForNavigation,
+  timeInterval: 2000,
+  distanceInterval: 1,
+  pausesUpdatesAutomatically: false,
+  showsBackgroundLocationIndicator: true,
+  foregroundService: {
+    notificationTitle: "러닝 중",
+    notificationBody: buildRunningNotificationBody({ distance, seconds }),
+    notificationColor: "#4169E1",
+    killServiceOnDestroy: false,
+  },
+});

--- a/tasks/locationTask.ts
+++ b/tasks/locationTask.ts
@@ -1,6 +1,14 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Location from "expo-location";
 import * as TaskManager from "expo-task-manager";
+import { getDistance } from "geolib";
+import {
+  BG_NOTIFICATION_METRICS_KEY,
+  BG_NOTIFICATION_UPDATED_AT_KEY,
+  buildBackgroundLocationOptions,
+  parseRunningNotificationMetrics,
+  RUNNING_NOTIFICATION_UPDATE_INTERVAL_MS,
+} from "@/lib/runningNotification";
 
 export const BACKGROUND_LOCATION_TASK = "BACKGROUND_LOCATION_TASK";
 export const BG_LOCATION_KEY = "@bg_locations";
@@ -31,6 +39,53 @@ const parseStoredLocations = (raw: string | null): BackgroundLocationPoint[] => 
   } catch {
     return [];
   }
+};
+
+const calculateDistance = (locations: BackgroundLocationPoint[]) => {
+  let distance = 0;
+
+  for (let index = 1; index < locations.length; index += 1) {
+    distance += getDistance(locations[index - 1], locations[index]);
+  }
+
+  return distance;
+};
+
+const updateAndroidForegroundNotification = async ({
+  locations,
+  backgroundStartedAt,
+}: {
+  locations: BackgroundLocationPoint[];
+  backgroundStartedAt: string;
+}) => {
+  const now = Date.now();
+  const lastUpdated = Number(
+    await AsyncStorage.getItem(BG_NOTIFICATION_UPDATED_AT_KEY)
+  );
+
+  if (
+    Number.isFinite(lastUpdated) &&
+    now - lastUpdated < RUNNING_NOTIFICATION_UPDATE_INTERVAL_MS
+  ) {
+    return;
+  }
+
+  const baseMetrics = parseRunningNotificationMetrics(
+    await AsyncStorage.getItem(BG_NOTIFICATION_METRICS_KEY)
+  );
+  const offset = Number(backgroundStartedAt);
+  const backgroundSeconds = Number.isFinite(offset)
+    ? Math.max(0, Math.floor((now - offset) / 1000))
+    : 0;
+
+  await AsyncStorage.setItem(BG_NOTIFICATION_UPDATED_AT_KEY, String(now));
+  await Location.startLocationUpdatesAsync(
+    BACKGROUND_LOCATION_TASK,
+    buildBackgroundLocationOptions({
+      distance: baseMetrics.distance + calculateDistance(locations),
+      seconds: baseMetrics.seconds + backgroundSeconds,
+    })
+  );
 };
 
 TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
@@ -64,6 +119,10 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
     const stored = parseStoredLocations(raw);
     const updated = [...stored, ...points].slice(-MAX_BACKGROUND_LOCATIONS);
     await AsyncStorage.setItem(BG_LOCATION_KEY, JSON.stringify(updated));
+    await updateAndroidForegroundNotification({
+      locations: updated,
+      backgroundStartedAt,
+    });
   } catch {
     // Background tasks must fail quietly; foreground sync can continue later.
   }


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추가/수정 내용
- Android foreground service notification body에 현재 러닝 거리, 시간, 페이스를 표시하도록 `runningNotification` 유틸을 추가했습니다.
- 백그라운드 위치 task 시작 시 동일 옵션 빌더를 사용하도록 정리했습니다.
- 앱이 active 상태일 때는 러닝 지표 변경을 15초 간격으로 알림에 반영합니다.
- 앱이 background 상태일 때는 `TaskManager` 위치 이벤트 기준으로 AsyncStorage에 저장한 기준 지표와 백그라운드 위치 누적 거리를 합산해 알림을 갱신합니다.
- 기존 foreground 위치 추적, 러닝 store 구조, STOMP 구조는 변경하지 않았습니다.

## 테스트
- [ ] Android EAS development build에서 러닝 시작 후 상태 표시줄/알림에 거리, 시간, 페이스가 갱신되는지 확인 필요
- [ ] 화면 off/background 상태에서도 Android foreground notification 지표가 위치 이벤트 기준으로 갱신되는지 확인 필요
- [ ] 앱 복귀 후 기존 백그라운드 위치 수집/동기화가 유지되는지 확인 필요
- [x] `npx tsc --noEmit --pretty false` 실행
  - 기존 프로젝트 타입 에러로 실패했습니다. 이번 변경 파일(`hooks/useLocationTracking.ts`, `lib/runningNotification.ts`, `tasks/locationTask.ts`)의 신규 타입 에러는 출력되지 않았습니다.

Closes #52