### PR TITLE
[Feat] 러닝 중 Android foreground notification에 거리/시간/페이스 표시

### DIFF
--- a/BACKGROUND_RUNNING_IMPLEMENTATION_NOTES.md
+++ b/BACKGROUND_RUNNING_IMPLEMENTATION_NOTES.md
@@ -1,0 +1,100 @@
+# Background Running Implementation Notes
+
+## 목적
+
+러닝 중 앱이 foreground를 벗어나도 기록이 끊기지 않도록 Expo 기반 백그라운드 위치 수집 구조를 추가했다.  
+단순 위치 추적이 아니라, foreground 복귀 후 거리/시간/경로를 실제 러닝 상태에 다시 합치는 흐름까지 포함한다.
+
+## 기존 문제
+
+- `watchPositionAsync()` 만으로는 앱이 background로 전환되면 GPS 추적이 사실상 끊겼다.
+- iOS/Android 모두 background 상태에서 WebSocket 연결 지속을 신뢰하기 어려웠다.
+- background 동안 쌓인 좌표를 foreground store에 다시 반영하는 경로가 없었다.
+
+## 구현한 것
+
+### 1. Background location task 분리
+
+- `tasks/locationTask.ts` 에서 `TaskManager.defineTask()` 를 모듈 최상위에 등록
+- 러닝 중일 때만 background 위치 이벤트를 수신
+- 좌표는 Zustand store에 직접 쓰지 않고 `AsyncStorage` 에 버퍼링
+- 장시간 러닝을 고려해 background 좌표 버퍼를 최대 `5000`개로 제한
+
+### 2. Foreground / background 추적 역할 분리
+
+- `hooks/useLocationTracking.ts`
+- 평소에는 foreground 위치 추적 유지
+- 러닝 시작 시 `startLocationUpdatesAsync()` 로 background 위치 수집 시작
+- 러닝 종료 시 background task 중지 및 임시 key 정리
+
+### 3. Foreground 복귀 동기화
+
+- `lib/syncBackgroundLocations.ts`
+- background 동안 저장된 좌표 배열을 읽어서 거리와 경과 시간을 계산
+- foreground 복귀 시 Zustand 러닝 상태에 누적 반영
+- 솔로 러닝 기록 경로와 진행 거리 배열도 함께 append
+
+### 4. STOMP 위치 전송 보완
+
+- `hooks/running/useStomp.ts`
+- 앱이 active 상태가 아니거나 소켓이 끊긴 경우 위치 frame을 즉시 버리지 않고 buffer에 저장
+- foreground 복귀 또는 재연결 후 순서대로 flush
+
+### 5. Android foreground notification
+
+- 러닝 중 Android foreground service notification 표시
+- 알림 body에 `거리 / 시간 / 페이스` 표시
+- foreground에서는 주기적으로, background에서는 위치 이벤트 기준으로 알림 내용 갱신
+- Android 13+ 대응을 위해 `POST_NOTIFICATIONS` 권한 요청 추가
+
+### 6. Background 진입 직전 알림 갱신
+
+- 앱이 `active -> background` 로 바뀌는 순간
+- 현재 거리/시간 기준으로 notification body를 먼저 갱신
+- 그 다음 background offset / 위치 버퍼를 저장하도록 순서 조정
+
+## 주요 기술 선택 이유
+
+### `expo-task-manager` + `expo-location`
+
+- Expo managed workflow 안에서 background location 을 구현하려면 표준 경로에 가깝다.
+- foreground 전용인 `watchPositionAsync()` 를 그대로 유지하는 것보다 러닝 앱 요구사항에 맞다.
+
+### `AsyncStorage` 버퍼링
+
+- background task 내부에서 store 직접 접근을 피할 수 있다.
+- foreground 복귀 시점에 안전하게 거리/시간/좌표를 재계산할 수 있다.
+
+### STOMP 재전송 buffer
+
+- iOS/Android background 상태에서 WebSocket 지속 연결을 신뢰하지 않는 방향이 더 안전하다.
+- 실시간성이 잠깐 깨져도, foreground 복귀 후 전송 유실을 줄일 수 있다.
+
+## 구현하면서 신경 쓴 점
+
+- background task 안에서 Zustand store 직접 접근 금지
+- AppState 전환 시점과 background task 시점을 분리
+- foreground UX는 최대한 유지하고 러닝 중일 때만 background 추적 로직 활성화
+- Android notification 갱신 주기를 과도하게 짧게 두지 않고 throttle 적용
+
+## 현재 남아 있는 한계
+
+- GPS drift 필터가 완전하지 않아 정지 상태에서도 작은 거리 증가가 생길 수 있다.
+- 알림 갱신은 초단위 실시간 ticker가 아니라 위치 이벤트 + throttle 기반이다.
+- Expo dev build 환경 기준이며 Expo Go 에서는 background location / task 검증이 어렵다.
+- Android 제조사별 배터리 정책, 알림 정책 차이로 실제 표시 방식이 달라질 수 있다.
+
+## 이력서용 포인트
+
+- Expo 기반 러닝 앱에서 foreground 중심 위치 추적을 background 지속 추적으로 확장
+- background 위치 버퍼링과 foreground 복귀 동기화 구조 설계
+- WebSocket 비연속 구간을 고려한 위치 frame buffer / 재전송 흐름 구현
+- Android foreground notification 에 러닝 지표 연동
+
+## 블로그용 포인트
+
+- `watchPositionAsync()` 만으로는 러닝 앱 background 요구사항을 만족하기 어려운 이유
+- Expo managed workflow 에서 `TaskManager.defineTask()` 를 어디에 둬야 하는지
+- background task 에서 store를 직접 쓰지 않고 `AsyncStorage` 를 중간 버퍼로 둔 이유
+- foreground 복귀 후 거리/시간/경로를 다시 합치는 방식
+- Android foreground service notification 을 러닝 지표와 연결한 과정

--- a/component/Modal/PrepareRunModal/PrepareCrew.tsx
+++ b/component/Modal/PrepareRunModal/PrepareCrew.tsx
@@ -36,14 +36,16 @@ export const PrepareCrew = () => {
 
   useInterval(
     () => {
+      if (!myLocation) return;
       sendLocation(myLocation, isReady);
     },
     myLocation ? 1000 : null
   );
 
   useEffect(() => {
+    if (!myLocation) return;
     sendLocation(myLocation, isReady);
-  }, [isReady]);
+  }, [isReady, myLocation]);
   useEffect(() => {
     if (
       crewRunningPrepareParticipant.length > 0 &&

--- a/component/SoloRunningText.tsx
+++ b/component/SoloRunningText.tsx
@@ -5,6 +5,7 @@ import { useLocationStore } from "@/store/useLocationStore";
 import { useRunningStore } from "@/store/useRunningStore";
 import { convertSpeedToPace } from "@/lib/convertSpeedToPace";
 import { useShallow } from "zustand/react/shallow";
+import { getFilteredRunningSpeed } from "@/lib/runningLocationFilter";
 
 function paceStringToSeconds(paceStr: string): number {
   const [min, sec] = paceStr.split(/['"]/).map(Number);
@@ -27,7 +28,7 @@ export const SoloRunningText = () => {
     }))
   );
   const myLocation = useLocationStore((state) => state.myLocation);
-  const currentPace = convertSpeedToPace(myLocation?.speed!);
+  const currentPace = convertSpeedToPace(getFilteredRunningSpeed(myLocation));
   const targetSec = paceStringToSeconds(targetPace);
   const currentSec = paceStringToSeconds(currentPace);
   const winning = targetSec - currentSec > 0 ? true : false;

--- a/hooks/running/useCompetitorRunning.ts
+++ b/hooks/running/useCompetitorRunning.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchCompetitor } from "../../lib/map/fetchCompetitor";
 import { useEffect, useRef, useState } from "react";
 import useInterval from "./useInterval";
-import { getDistance, getPathLength } from "geolib";
+import { getPathLength } from "geolib";
 import { location } from "../../types";
 import { convertSpeedToPace } from "../../lib/convertSpeedToPace";
 import { useStomp } from "./useStomp";
@@ -10,6 +10,10 @@ import { useLocationStore } from "@/store/useLocationStore";
 import { useShallow } from "zustand/react/shallow";
 import { useRunningStore } from "@/store/useRunningStore";
 import { useCourseStore } from "@/store/useCourseStore";
+import {
+  getFilteredRunningDistance,
+  hasNewerLocationTimestamp,
+} from "@/lib/runningLocationFilter";
 export const useCompetitorRunning = () => {
   const { selectedCourseId, currentCourses, totalDistance, setTotalDistance } = useCourseStore(
     useShallow((state) => ({
@@ -55,6 +59,7 @@ export const useCompetitorRunning = () => {
   const [progress, setProgress] = useState<number[]>([]);
   const [competitorProgress, setCompetitorProgress] = useState<number>(0);
   const prevLocation = useRef<location | null>(null);
+  const lastSentTimestamp = useRef(0);
   const [distanceToCompetitor, setDistanceToCompetitor] = useState<number>(0);
   const [winning, setWinning] = useState<boolean>(true);
   const [index, setIndex] = useState<number>(0);
@@ -89,8 +94,11 @@ export const useCompetitorRunning = () => {
         if (index < (data?.progress.length ?? 1) - 1) {
           setIndex((prev) => prev + 1);
         }
-        sendLocation(myLocation);
-        setSpeed(convertSpeedToPace(myLocation?.speed));
+        if (hasNewerLocationTimestamp(lastSentTimestamp.current, myLocation)) {
+          lastSentTimestamp.current = myLocation.timestamp;
+          sendLocation(myLocation);
+        }
+        setSpeed(convertSpeedToPace(myLocation?.speed ?? 0));
       }
     },
     data && runningStatus === 'go' ? 500 : null
@@ -106,7 +114,7 @@ export const useCompetitorRunning = () => {
     if (stompLocation) {
       if (prevLocation.current) {
         if (stompLocation?.runningStatus === "ONGOING") {
-          const distance = getDistance(
+          const distance = getFilteredRunningDistance(
             {
               latitude: prevLocation.current.latitude,
               longitude: prevLocation.current.longitude,
@@ -114,8 +122,14 @@ export const useCompetitorRunning = () => {
             {
               latitude: stompLocation?.latitude,
               longitude: stompLocation?.longitude,
+              accuracy: stompLocation?.accuracy,
+              speed: stompLocation?.speed,
             }
           );
+          if (distance <= 0) {
+            prevLocation.current = stompLocation;
+            return;
+          }
           setRunDistance((prev) => prev + distance);
         }
 

--- a/hooks/running/useCompetitorRunning.ts
+++ b/hooks/running/useCompetitorRunning.ts
@@ -12,6 +12,7 @@ import { useRunningStore } from "@/store/useRunningStore";
 import { useCourseStore } from "@/store/useCourseStore";
 import {
   getFilteredRunningDistance,
+  getFilteredRunningSpeed,
   hasNewerLocationTimestamp,
 } from "@/lib/runningLocationFilter";
 export const useCompetitorRunning = () => {
@@ -98,7 +99,7 @@ export const useCompetitorRunning = () => {
           lastSentTimestamp.current = myLocation.timestamp;
           sendLocation(myLocation);
         }
-        setSpeed(convertSpeedToPace(myLocation?.speed ?? 0));
+        setSpeed(convertSpeedToPace(getFilteredRunningSpeed(myLocation)));
       }
     },
     data && runningStatus === 'go' ? 500 : null
@@ -127,7 +128,6 @@ export const useCompetitorRunning = () => {
             }
           );
           if (distance <= 0) {
-            prevLocation.current = stompLocation;
             return;
           }
           setRunDistance((prev) => prev + distance);

--- a/hooks/running/useCrewRunning.ts
+++ b/hooks/running/useCrewRunning.ts
@@ -12,6 +12,7 @@ import { useStompStore } from "@/store/useStompStore";
 import { useAuthStore } from "@/store/useAuthStore";
 import {
   getFilteredRunningDistance,
+  getFilteredRunningSpeed,
   hasNewerLocationTimestamp,
 } from "@/lib/runningLocationFilter";
 export const useCrewRunning = () => {
@@ -80,7 +81,7 @@ export const useCrewRunning = () => {
           lastSentTimestamp.current = myLocation.timestamp;
           sendLocation(myLocation);
         }
-        setSpeed(convertSpeedToPace(myLocation?.speed ?? 0));
+        setSpeed(convertSpeedToPace(getFilteredRunningSpeed(myLocation)));
       }
     },
     runningStatus === "go" && myLocation ? 500 : null
@@ -114,6 +115,14 @@ export const useCrewRunning = () => {
           speed: stompLocation?.speed,
         }
       );
+
+      if (distance <= 0) {
+        setCrewRunningParticipants(userId, {
+          ...prevParticipant,
+          runningStatus,
+        });
+        return;
+      }
       setCrewRunningParticipants(userId, {
         latitude,
         longitude,

--- a/hooks/running/useCrewRunning.ts
+++ b/hooks/running/useCrewRunning.ts
@@ -1,6 +1,5 @@
 import { CrewRunningParticipant } from "./../../types/index";
 import { useEffect, useRef, useState } from "react";
-import { getDistance } from "geolib";
 import { location } from "../../types";
 import { convertSpeedToPace } from "../../lib/convertSpeedToPace";
 import { useStomp } from "./useStomp";
@@ -11,6 +10,10 @@ import { useCourseStore } from "@/store/useCourseStore";
 import useInterval from "./useInterval";
 import { useStompStore } from "@/store/useStompStore";
 import { useAuthStore } from "@/store/useAuthStore";
+import {
+  getFilteredRunningDistance,
+  hasNewerLocationTimestamp,
+} from "@/lib/runningLocationFilter";
 export const useCrewRunning = () => {
   const { selectedCourseId, currentCourses } = useCourseStore(
     useShallow((state) => ({
@@ -50,6 +53,7 @@ export const useCrewRunning = () => {
   const [speed, setSpeed] = useState<string>("00'00\"");
   const [index, setIndex] = useState<number>(0);
   const [text, setText] = useState<string>("");
+  const lastSentTimestamp = useRef(0);
 
   useEffect(() => {
     if (selectedCourseId) {
@@ -72,8 +76,11 @@ export const useCrewRunning = () => {
     () => {
       if (myLocation) {
         setIndex((prev) => prev + 1);
-        sendLocation(myLocation);
-        setSpeed(convertSpeedToPace(myLocation?.speed));
+        if (hasNewerLocationTimestamp(lastSentTimestamp.current, myLocation)) {
+          lastSentTimestamp.current = myLocation.timestamp;
+          sendLocation(myLocation);
+        }
+        setSpeed(convertSpeedToPace(myLocation?.speed ?? 0));
       }
     },
     runningStatus === "go" && myLocation ? 500 : null
@@ -95,7 +102,7 @@ export const useCrewRunning = () => {
     if (prevParticipant) {
       const prevDistance = prevParticipant.distance ?? 0;
 
-      distance = getDistance(
+      distance = getFilteredRunningDistance(
         {
           latitude: prevParticipant.latitude,
           longitude: prevParticipant.longitude,
@@ -103,6 +110,8 @@ export const useCrewRunning = () => {
         {
           latitude,
           longitude,
+          accuracy: stompLocation?.accuracy,
+          speed: stompLocation?.speed,
         }
       );
       setCrewRunningParticipants(userId, {

--- a/hooks/running/useSoloCourseRunning.ts
+++ b/hooks/running/useSoloCourseRunning.ts
@@ -1,7 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { location } from "@/types";
-import { getDistance } from "geolib";
-import { isSoloRunningRecord } from "../../lib/discriminateRecordType";
 import { convertSpeedToPace } from "../../lib/convertSpeedToPace";
 import { useLocationStore } from "@/store/useLocationStore";
 import { useRunningStore } from "@/store/useRunningStore";
@@ -9,6 +7,10 @@ import { useShallow } from "zustand/react/shallow";
 import useInterval from "./useInterval";
 import { useCourseStore } from "@/store/useCourseStore";
 import { useStomp } from "./useStomp";
+import {
+  getFilteredRunningDistance,
+  hasNewerLocationTimestamp,
+} from "@/lib/runningLocationFilter";
 
 export const useSoloCourseRunning = () => {
   const {
@@ -43,6 +45,7 @@ export const useSoloCourseRunning = () => {
   const [progress, setProgress] = useState<number[]>([]);
   const [speed, setSpeed] = useState<string>(`0'00''`);
   const [index, setIndex] = useState<number>(0);
+  const lastSentTimestamp = useRef(0);
   useInterval(() => {
     if (runningStatus === "go") {
       setSeconds((prev) => prev + 1);
@@ -60,9 +63,12 @@ export const useSoloCourseRunning = () => {
   useInterval(() => {
     if (runningStatus === "go" && myLocation) {
       if (runDistance > 0) {
-        setSpeed(convertSpeedToPace(myLocation?.speed!));
+        setSpeed(convertSpeedToPace(myLocation?.speed ?? 0));
       }
-      sendLocation(myLocation);
+      if (hasNewerLocationTimestamp(lastSentTimestamp.current, myLocation)) {
+        lastSentTimestamp.current = myLocation.timestamp;
+        sendLocation(myLocation);
+      }
       setIndex(prev => prev+1);
     }
   }, 500);
@@ -71,7 +77,7 @@ export const useSoloCourseRunning = () => {
     if (stompLocation) {
       if (prevLocation.current) {
         if (stompLocation?.runningStatus === "ONGOING") {
-          const distance = getDistance(
+          const distance = getFilteredRunningDistance(
             {
               latitude: prevLocation.current.latitude,
               longitude: prevLocation.current.longitude,
@@ -79,8 +85,15 @@ export const useSoloCourseRunning = () => {
             {
               latitude: stompLocation?.latitude,
               longitude: stompLocation?.longitude,
+              accuracy: stompLocation?.accuracy,
+              speed: stompLocation?.speed,
             }
           );
+
+          if (distance <= 0) {
+            prevLocation.current = stompLocation;
+            return;
+          }
           setRunDistance((prev) => prev + distance);
         }
       }

--- a/hooks/running/useSoloCourseRunning.ts
+++ b/hooks/running/useSoloCourseRunning.ts
@@ -9,6 +9,7 @@ import { useCourseStore } from "@/store/useCourseStore";
 import { useStomp } from "./useStomp";
 import {
   getFilteredRunningDistance,
+  getFilteredRunningSpeed,
   hasNewerLocationTimestamp,
 } from "@/lib/runningLocationFilter";
 
@@ -63,7 +64,7 @@ export const useSoloCourseRunning = () => {
   useInterval(() => {
     if (runningStatus === "go" && myLocation) {
       if (runDistance > 0) {
-        setSpeed(convertSpeedToPace(myLocation?.speed ?? 0));
+        setSpeed(convertSpeedToPace(getFilteredRunningSpeed(myLocation)));
       }
       if (hasNewerLocationTimestamp(lastSentTimestamp.current, myLocation)) {
         lastSentTimestamp.current = myLocation.timestamp;
@@ -91,7 +92,6 @@ export const useSoloCourseRunning = () => {
           );
 
           if (distance <= 0) {
-            prevLocation.current = stompLocation;
             return;
           }
           setRunDistance((prev) => prev + distance);

--- a/hooks/running/useSoloRunning.ts
+++ b/hooks/running/useSoloRunning.ts
@@ -44,6 +44,7 @@ export const useSoloRunning = () => {
   >([]);
   const skipSyncedProgressEffect = useRef(false);
   const lastProgressTimestamp = useRef(0);
+  const lastAcceptedLocation = useRef<location | null>(null);
   const PACE_WINDOW_SECONDS = 10;
   useEffect(() => {
     if (runningStatus === "go") {
@@ -84,6 +85,23 @@ export const useSoloRunning = () => {
       }
 
       lastProgressTimestamp.current = newLocation.timestamp;
+
+      if (!lastAcceptedLocation.current) {
+        lastAcceptedLocation.current = newLocation;
+        setProgress((prev) => [...prev, newLocation]);
+        return;
+      }
+
+      const filteredDistance = getFilteredRunningDistance(
+        lastAcceptedLocation.current,
+        newLocation
+      );
+
+      if (filteredDistance <= 0) {
+        return;
+      }
+
+      lastAcceptedLocation.current = newLocation;
       setProgress((prev) => {
         const newProgress = [...prev, newLocation];
         return newProgress;
@@ -92,6 +110,10 @@ export const useSoloRunning = () => {
   }, 2000);
   useEffect(() => {
     if (runningStatus === "countdown" && myLocation) {
+      lastAcceptedLocation.current = {
+        latitude: myLocation.latitude,
+        longitude: myLocation.longitude,
+      };
       setRunningRecord({
         runningTime: 0,
         courseName: "",
@@ -107,6 +129,13 @@ export const useSoloRunning = () => {
         if (!Array.isArray(locations) || locations.length === 0) return;
 
         skipSyncedProgressEffect.current = true;
+        const lastLocation = locations[locations.length - 1];
+        if (lastLocation) {
+          lastAcceptedLocation.current = {
+            latitude: lastLocation.latitude,
+            longitude: lastLocation.longitude,
+          };
+        }
         setProgress((prev) => [
           ...prev,
           ...locations.map(({ latitude, longitude }) => ({

--- a/hooks/running/useSoloRunning.ts
+++ b/hooks/running/useSoloRunning.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { DeviceEventEmitter } from "react-native";
 import { location } from "@/types";
-import { getDistance } from "geolib";
 import { isSoloRunningRecord } from "../../lib/discriminateRecordType";
 import { calculatePaceFromDistance } from "../../lib/convertSpeedToPace";
 import { useLocationStore } from "@/store/useLocationStore";
@@ -12,6 +11,10 @@ import {
   BACKGROUND_LOCATION_SYNC_EVENT,
 } from "@/lib/syncBackgroundLocations";
 import { BackgroundLocationPoint } from "@/tasks/locationTask";
+import {
+  getFilteredRunningDistance,
+  hasNewerLocationTimestamp,
+} from "@/lib/runningLocationFilter";
 
 export const useSoloRunning = () => {
   const {
@@ -40,6 +43,7 @@ export const useSoloRunning = () => {
     { timestamp: number; distance: number }[]
   >([]);
   const skipSyncedProgressEffect = useRef(false);
+  const lastProgressTimestamp = useRef(0);
   const PACE_WINDOW_SECONDS = 10;
   useEffect(() => {
     if (runningStatus === "go") {
@@ -70,7 +74,16 @@ export const useSoloRunning = () => {
       const newLocation = {
         latitude: myLocation.latitude,
         longitude: myLocation.longitude,
+        accuracy: myLocation.accuracy,
+        speed: myLocation.speed,
+        timestamp: myLocation.timestamp,
       };
+
+      if (!hasNewerLocationTimestamp(lastProgressTimestamp.current, newLocation)) {
+        return;
+      }
+
+      lastProgressTimestamp.current = newLocation.timestamp;
       setProgress((prev) => {
         const newProgress = [...prev, newLocation];
         return newProgress;
@@ -115,10 +128,14 @@ export const useSoloRunning = () => {
 
     if (progress.length >= 2 && runningStatus === "go") {
       const now = Date.now();
-      const distance = getDistance(
+      const distance = getFilteredRunningDistance(
         progress[progress.length - 1],
         progress[progress.length - 2]
       );
+
+      if (distance <= 0) {
+        return;
+      }
 
       // 최근 거리 버퍼 업데이트 (10초 윈도우 유지)
       const newBuffer = [
@@ -155,10 +172,14 @@ export const useSoloRunning = () => {
     }
 
     if (progress.length >= 2) {
-      const distance = getDistance(
+      const distance = getFilteredRunningDistance(
         progress[progress.length - 1],
         progress[progress.length - 2]
       );
+
+      if (distance <= 0) {
+        return;
+      }
 
       // 전체 거리 업데이트
       setRunDistance((prev) => prev + distance);

--- a/hooks/running/useStomp.ts
+++ b/hooks/running/useStomp.ts
@@ -14,6 +14,9 @@ type StompMessage = {
   runningStatus?: string;
   latitude?: number;
   longitude?: number;
+  accuracy?: number;
+  speed?: number;
+  timestamp?: number;
   userId?: string;
   username?: string;
 };
@@ -142,6 +145,9 @@ export function useStomp() {
           runningStatus: data?.runningStatus,
           latitude: data?.latitude,
           longitude: data?.longitude,
+          accuracy: data?.accuracy,
+          speed: data?.speed,
+          timestamp: data?.timestamp,
           userId: data?.userId,
           username: data?.username,
         } as any));

--- a/hooks/useLocationTracking.ts
+++ b/hooks/useLocationTracking.ts
@@ -155,7 +155,10 @@ export const useLocationTracking = () => {
         distanceInterval: isRunning ? 1 : 5,
       },
       (newLocation) => {
-        setMyLocation(newLocation.coords);
+        setMyLocation({
+          ...newLocation.coords,
+          timestamp: newLocation.timestamp,
+        });
       }
     );
     subscription.current = sub;
@@ -244,7 +247,13 @@ export const useLocationTracking = () => {
         setMyLocation({
           latitude: lastLocation.latitude,
           longitude: lastLocation.longitude,
-        } as Location.LocationObjectCoords);
+          accuracy: lastLocation.accuracy ?? null,
+          speed: lastLocation.speed ?? null,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          timestamp: lastLocation.timestamp,
+        });
       }
 
       if (result.newDistance > 0) {

--- a/lib/runningLocationFilter.ts
+++ b/lib/runningLocationFilter.ts
@@ -1,0 +1,52 @@
+import { getDistance } from "geolib";
+
+type LocationSample = {
+  latitude: number;
+  longitude: number;
+  accuracy?: number | null;
+  speed?: number | null;
+  timestamp?: number;
+};
+
+export const MIN_RUNNING_MOVEMENT_METERS = 2;
+export const MAX_RUNNING_ACCURACY_METERS = 35;
+export const STATIONARY_SPEED_THRESHOLD = 0.8;
+export const STATIONARY_DISTANCE_THRESHOLD = 5;
+
+export const hasNewerLocationTimestamp = (
+  previousTimestamp: number,
+  nextLocation: LocationSample | null | undefined
+) => {
+  if (typeof nextLocation?.timestamp !== "number") return false;
+  return nextLocation.timestamp > previousTimestamp;
+};
+
+export const getFilteredRunningDistance = (
+  previousLocation: LocationSample | null | undefined,
+  nextLocation: LocationSample | null | undefined
+) => {
+  if (!previousLocation || !nextLocation) return 0;
+
+  if (
+    typeof nextLocation.accuracy === "number" &&
+    nextLocation.accuracy > MAX_RUNNING_ACCURACY_METERS
+  ) {
+    return 0;
+  }
+
+  const distance = getDistance(previousLocation, nextLocation);
+  if (distance < MIN_RUNNING_MOVEMENT_METERS) {
+    return 0;
+  }
+
+  if (
+    typeof nextLocation.speed === "number" &&
+    nextLocation.speed >= 0 &&
+    nextLocation.speed < STATIONARY_SPEED_THRESHOLD &&
+    distance < STATIONARY_DISTANCE_THRESHOLD
+  ) {
+    return 0;
+  }
+
+  return distance;
+};

--- a/lib/runningLocationFilter.ts
+++ b/lib/runningLocationFilter.ts
@@ -8,10 +8,11 @@ type LocationSample = {
   timestamp?: number;
 };
 
-export const MIN_RUNNING_MOVEMENT_METERS = 2;
-export const MAX_RUNNING_ACCURACY_METERS = 35;
-export const STATIONARY_SPEED_THRESHOLD = 0.8;
-export const STATIONARY_DISTANCE_THRESHOLD = 5;
+export const MIN_RUNNING_MOVEMENT_METERS = 3;
+export const MAX_RUNNING_ACCURACY_METERS = 25;
+export const STATIONARY_SPEED_THRESHOLD = 1.2;
+export const STATIONARY_DISTANCE_THRESHOLD = 8;
+export const UNKNOWN_SPEED_DISTANCE_THRESHOLD = 6;
 
 export const hasNewerLocationTimestamp = (
   previousTimestamp: number,
@@ -40,6 +41,13 @@ export const getFilteredRunningDistance = (
   }
 
   if (
+    typeof nextLocation.speed !== "number" &&
+    distance < UNKNOWN_SPEED_DISTANCE_THRESHOLD
+  ) {
+    return 0;
+  }
+
+  if (
     typeof nextLocation.speed === "number" &&
     nextLocation.speed >= 0 &&
     nextLocation.speed < STATIONARY_SPEED_THRESHOLD &&
@@ -49,4 +57,27 @@ export const getFilteredRunningDistance = (
   }
 
   return distance;
+};
+
+export const getFilteredRunningSpeed = (
+  location: LocationSample | null | undefined
+) => {
+  if (!location) return 0;
+
+  if (
+    typeof location.accuracy === "number" &&
+    location.accuracy > MAX_RUNNING_ACCURACY_METERS
+  ) {
+    return 0;
+  }
+
+  if (typeof location.speed !== "number" || location.speed <= 0) {
+    return 0;
+  }
+
+  if (location.speed < STATIONARY_SPEED_THRESHOLD) {
+    return 0;
+  }
+
+  return location.speed;
 };

--- a/lib/syncBackgroundLocations.ts
+++ b/lib/syncBackgroundLocations.ts
@@ -1,10 +1,10 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { getDistance } from "geolib";
 import {
   BG_LOCATION_KEY,
   BG_SECONDS_OFFSET_KEY,
   BackgroundLocationPoint,
 } from "@/tasks/locationTask";
+import { getFilteredRunningDistance } from "@/lib/runningLocationFilter";
 
 export const BACKGROUND_LOCATION_SYNC_EVENT = "background-location-sync";
 
@@ -60,20 +60,31 @@ export async function syncBackgroundLocations(): Promise<BackgroundLocationSyncR
   }
 
   const segmentDistances: number[] = [];
+  const acceptedLocations: BackgroundLocationPoint[] = [locations[0]];
+  let previousAcceptedLocation = locations[0];
   let newDistance = 0;
 
   for (let index = 1; index < locations.length; index += 1) {
-    const distance = getDistance(locations[index - 1], locations[index]);
+    const nextLocation = locations[index];
+    const distance = getFilteredRunningDistance(
+      previousAcceptedLocation,
+      nextLocation
+    );
+
+    if (distance <= 0) continue;
+
     segmentDistances.push(distance);
+    acceptedLocations.push(nextLocation);
     newDistance += distance;
+    previousAcceptedLocation = nextLocation;
   }
 
   return {
     newDistance,
-    newCoords: locations
+    newCoords: acceptedLocations
       .slice(1)
       .map(({ longitude, latitude }) => [longitude, latitude]),
-    locations,
+    locations: acceptedLocations,
     segmentDistances,
     secondsElapsed,
   };

--- a/store/useLocationStore.ts
+++ b/store/useLocationStore.ts
@@ -1,4 +1,9 @@
-import { CourseResponse, crewRunningLocation, runningLocation } from "@/types";
+import {
+  CourseResponse,
+  crewRunningLocation,
+  runningLocation,
+  TrackedLocation,
+} from "@/types";
 import {
   LocationObjectCoords,
   LocationPermissionResponse,
@@ -9,8 +14,8 @@ import { Alert } from "react-native";
 import { Region } from "react-native-maps/lib/sharedTypes";
 import { create } from "zustand";
 interface LocationState {
-  myLocation: LocationObjectCoords | null;
-  setMyLocation: (loc: LocationObjectCoords | null) => void;
+  myLocation: TrackedLocation | null;
+  setMyLocation: (loc: TrackedLocation | null) => void;
 
   permissionStatus: LocationPermissionResponse | null;
   setPermissionStatus: (perm: LocationPermissionResponse | null) => void;

--- a/tasks/locationTask.ts
+++ b/tasks/locationTask.ts
@@ -1,7 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Location from "expo-location";
 import * as TaskManager from "expo-task-manager";
-import { getDistance } from "geolib";
 import {
   BG_NOTIFICATION_METRICS_KEY,
   BG_NOTIFICATION_UPDATED_AT_KEY,
@@ -9,6 +8,7 @@ import {
   parseRunningNotificationMetrics,
   RUNNING_NOTIFICATION_UPDATE_INTERVAL_MS,
 } from "@/lib/runningNotification";
+import { getFilteredRunningDistance } from "@/lib/runningLocationFilter";
 
 export const BACKGROUND_LOCATION_TASK = "BACKGROUND_LOCATION_TASK";
 export const BG_LOCATION_KEY = "@bg_locations";
@@ -19,6 +19,8 @@ export type BackgroundLocationPoint = {
   latitude: number;
   longitude: number;
   timestamp: number;
+  accuracy: number | null;
+  speed: number | null;
 };
 
 // About 2h 45m at the current 2s collection interval.
@@ -43,9 +45,19 @@ const parseStoredLocations = (raw: string | null): BackgroundLocationPoint[] => 
 
 const calculateDistance = (locations: BackgroundLocationPoint[]) => {
   let distance = 0;
+  let previousAcceptedLocation = locations[0];
 
   for (let index = 1; index < locations.length; index += 1) {
-    distance += getDistance(locations[index - 1], locations[index]);
+    const nextLocation = locations[index];
+    const filteredDistance = getFilteredRunningDistance(
+      previousAcceptedLocation,
+      nextLocation
+    );
+
+    if (filteredDistance <= 0) continue;
+
+    distance += filteredDistance;
+    previousAcceptedLocation = nextLocation;
   }
 
   return distance;
@@ -110,6 +122,12 @@ TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async ({ data, error }) => {
       latitude: location.coords.latitude,
       longitude: location.coords.longitude,
       timestamp: location.timestamp,
+      accuracy:
+        typeof location.coords.accuracy === "number"
+          ? location.coords.accuracy
+          : null,
+      speed:
+        typeof location.coords.speed === "number" ? location.coords.speed : null,
     }));
 
   if (points.length === 0) return;

--- a/types/index.ts
+++ b/types/index.ts
@@ -45,6 +45,10 @@ export interface location {
   longitude: number;
 }
 
+export interface TrackedLocation extends LocationObjectCoords {
+  timestamp: number;
+}
+
 export interface Place {
   name: string;
   formatted_address: string;


### PR DESCRIPTION
## 🎀 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✨ 추가/수정 내용
- Expo TaskManager 기반 백그라운드 러닝 위치 수집과 foreground 복귀 동기화 구조를 추가했습니다.
- Android foreground notification에 러닝 거리, 시간, 페이스를 표시하고 background 전환 시 즉시 갱신되도록 보강했습니다.
- Android 13+에서 알림이 실제로 보이도록 `POST_NOTIFICATIONS` 권한 요청과 권한 설정을 추가했습니다.
- STOMP 위치 전송은 background/재연결 구간에서 buffer 후 flush 하도록 보완했습니다.
- 러닝 위치 처리에 timestamp 기반 새 좌표 판별과 GPS drift 필터를 추가해 정지 중 거리/속도 흔들림을 줄였습니다.
- 작업 정리를 위해 `BACKGROUND_RUNNING_IMPLEMENTATION_NOTES.md` 문서를 루트에 추가했습니다.

## 🎊 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 테스트 메모
- `npx tsc --noEmit --pretty false` 실행
- 기존 프로젝트 전반의 타입 에러로 전체 통과는 하지 못했습니다.
- 이번 변경 범위 기준으로는 background 러닝 / notification / 위치 필터 로직을 중심으로 확인했습니다.
- Android foreground notification, background location task, 알림 권한 반영은 EAS dev build 또는 네이티브 재빌드 환경에서 확인이 필요합니다.

Closes #52